### PR TITLE
Object representation for Email Templates and integration with MongoDB

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,14 @@
-from flask import Flask, render_template, flash, jsonify, request, url_for, make_response, request, redirect
+from flask import (
+    Flask,
+    render_template,
+    flash,
+    jsonify,
+    request,
+    url_for,
+    make_response,
+    request,
+    redirect,
+)
 from flask_wtf import FlaskForm
 from wtforms import StringField, SelectField
 from wtforms.validators import DataRequired, Length
@@ -17,27 +27,29 @@ app.logger.addHandler(logging.StreamHandler(sys.stdout))
 app.logger.setLevel(logging.DEBUG)
 
 try:
-    skey = bytes(os.environ['FLASK_SECRET_KEY'], 'utf-8')
+    skey = bytes(os.environ["FLASK_SECRET_KEY"], "utf-8")
 except KeyError:
     # Testing environment
     skey = token_bytes(16)
 
 app.secret_key = skey
 
+
 @app.before_request
 def force_https():
-        criteria = [
-            app.debug,
-            request.is_secure,
-            request.headers.get('X-Forwarded-Proto', 'http') == 'https',
-        ]
+    criteria = [
+        app.debug,
+        request.is_secure,
+        request.headers.get("X-Forwarded-Proto", "http") == "https",
+    ]
 
-        if not any(criteria):
-            if request.url.startswith('http://'):
-                url = request.url.replace('http://', 'https://', 1)
-                code = 301
-                r = redirect(url, code=code)
-                return r
+    if not any(criteria):
+        if request.url.startswith("http://"):
+            url = request.url.replace("http://", "https://", 1)
+            code = 301
+            r = redirect(url, code=code)
+            return r
+
 
 @app.route("/", methods=["GET", "POST"])
 def landing():
@@ -66,6 +78,7 @@ def landing():
 @app.route("/aboutus")
 def aboutus():
     return render_template("aboutus.html")
+
 
 @app.route("/postcode/<postcode>")
 def postcode(postcode):

--- a/database.py
+++ b/database.py
@@ -30,6 +30,12 @@ class myDb:
 
     get_one(collection, query)
         Returns a cursor containing all the items from the collection that match the query.
+
+    get_all(collection):
+        Returns a cursor pointing to all of the items in a collection.
+
+    insert_one(collection,row):
+        Inserts the row into the chosen collection.
     """
 
     client = None
@@ -63,5 +69,11 @@ class myDb:
     def get_all(self, collection):
         return self.get_db_collection(collection).find()
 
+    def get_all_matching(self, collection, query):
+        return self.get_db_collection(collection).find(query)
+
     def insert_one(self, collection, row):
         return self.get_db_collection(collection).insert_one(row)
+
+    def update_one(self, collection, query, row):
+        return self.get_db_collection(collection).find_one_and_update(query, row)

--- a/database.py
+++ b/database.py
@@ -76,4 +76,4 @@ class myDb:
         return self.get_db_collection(collection).insert_one(row)
 
     def update_one(self, collection, query, row):
-        return self.get_db_collection(collection).find_one_and_update(query, row)
+        return self.get_db_collection(collection).replace_one(query, row)

--- a/database.py
+++ b/database.py
@@ -59,3 +59,9 @@ class myDb:
 
     def get_one(self, collection, query):
         return self.get_db_collection(collection).find_one(query)
+
+    def get_all(self, collection):
+        return self.get_db_collection(collection).find()
+
+    def insert_one(self, collection, row):
+        return self.get_db_collection(collection).insert_one(row)

--- a/emails.py
+++ b/emails.py
@@ -1,5 +1,6 @@
 from emailtemplates import get_existing_templates
 from mpdetails import get_mp_details
+import logging
 
 log = logging.getLogger("app")
 

--- a/emails.py
+++ b/emails.py
@@ -113,14 +113,12 @@ def draftEmails(myname, postcode, address):
     # Get all the empty templates from templates.py
     empty_email_templates = get_existing_templates()
     # Set the user dictionary to include the name of the person sending
-    user = {"name": myname}
+    user = {"name": myname, "address": address}
 
     for e in empty_email_templates:  # For each empty template
         if e.target is None:
             # If no defined target, use MP info to fill target fields
-            e.set_target(
-                name=MPname, email=MPemail, constituency=constituency, address=address
-            )
+            e.set_target(name=MPname, email=MPemail, constituency=constituency)
 
         # ToDo : Implement setting a cc
 

--- a/emails.py
+++ b/emails.py
@@ -5,6 +5,17 @@ import logging
 log = logging.getLogger("app")
 
 
+def validatePostcodeApi(postcode):
+    url_base = "http://api.postcodes.io/postcodes/"
+    postcode = postcode.replace(" ", "").upper()
+    try:
+        with urllib.request.urlopen(url_base + postcode) as url:
+            data = json.loads(url.read().decode())
+            return data["status"] == 200
+    except HTTPError:
+        return False
+
+
 def draftEmails(myname, postcode, address):
     ret = get_mp_details(postcode)
     constituency = ret["constituency"]

--- a/emails.py
+++ b/emails.py
@@ -1,3 +1,5 @@
+from urllib.error import HTTPError
+import urllib.request, json
 from emailtemplates import get_existing_templates
 from mpdetails import get_mp_details
 import logging
@@ -43,13 +45,18 @@ def draftEmails(myname, postcode, address):
         # ToDo : Implement setting a cc
 
         # Pass the dictionary containing user information to the template filler
-        success = e.fill(user)  # Returns true if successfully filled
+        try:
+            success = e.fill(user)  # Returns true if successfully filled
 
-        if success:
-            # Append successful templates to the list we return
-            filled_email_templates.append(e)
-        else:
-            log.debug("Failed to fill template, subject: {}".format(e.subject))
+            if success:
+                # Append successful templates to the list we return
+                filled_email_templates.append(e)
+        except AttributeError:
+            log.debug("Target set incorrectly, failed to fill template")
+            pass
+        except KeyError as err:
+            # Template not filled due to error in either template or user dict
+            log.debug(err)
             pass
 
     return filled_email_templates

--- a/emailtemplates.py
+++ b/emailtemplates.py
@@ -1,33 +1,116 @@
 """
-Template for the emails the app should send.
-ToDo:
-    1. Change Filling function to generic dictionary filler. (Completed)
-    2. Edit the functions that use the returned email templates to get information correctly (i.e. e.subject is fine, but now target email is e.target["email"]) (completed)
-    3. Gather all email templates automatically
-    4. Store them in a file
-    5. Allow people to submit template ideas
+Object representation of EmailTemplates, plus functions to store and retrieve templates from the database.
+
+Written by David Swarbrick (davidswarbrick) 2020
 """
 from database import myDb
+import logging
 
-# Instantiate the db
+
+# Instantiate the db connection:
 mongo = myDb()
+
+# Instantiate logging:
+log = logging.getLogger("app")
 
 
 class EmailTemplate:
-    """Store an unfilled email template, implement a filling function (which can be extended later)"""
+    """Object representation of email templates retrieved from database, providing construction from a dictionary, validation of inputs and template completion."""
 
-    def __init__(self, subject, body, target=None, cc=None):
-        self.subject = subject
-        self.body = body
-        self.target = None
-        self.cc = cc
+    def __init__(self, **email_template_dict):
+        # First, get the *required* aspects of the template,
+        # and raise an error if these cannot be found
+        try:
+            self.subject = email_template_dict["subject"]
+            self.body = self._parse_newlines_from_db(email_template_dict["body"])
+            self.name = email_template_dict["name"]
+            self.fields_used = email_template_dict["fields_used"]
+        except KeyError:
+            # If we cannot get a subject and body of the template it is unusable
+            log.debug("Could not decode subject, body and used fields for the template")
+            raise
+
+        # Second, attempt to get other details, and set default values if unavailable
+
+        try:
+            self.topics = email_template_dict["topics"]
+        except KeyError:
+            # An empty list of topics if none are stored
+            self.topics = []
+
+        try:
+            self.more_info_url = email_template_dict["more_info_url"]
+        except KeyError:
+            self.more_info_url = None
+
+        try:
+            self.author_url = email_template_dict["author_url"]
+        except KeyError:
+            self.author_url = None
+
+        try:
+            self.cc = email_template_dict["cc"]
+        except KeyError:
+            self.cc = []
+
+        try:
+            self.target = email_template_dict["target"]
+        except KeyError:
+            # If target is None that means we are setting the target from MP data
+            self.target = None
+
+        try:
+            self.public = email_template_dict["public"]
+        except KeyError:
+            self.public = False
+
+        # Set the filled state to false
         self.filled = False
+
+    @staticmethod
+    def _parse_newlines_to_db(string_to_database):
+        """Given a string, for example from a form input in HTML, replace newlines to prepare for storing the string in the database"""
+        # Using a workaround discovered by Rafee (rafeeJ) temporarily
+        return string_to_database.replace("\n", "\n")
+
+    @staticmethod
+    def _parse_newlines_from_db(string_from_database):
+        """Given a string from the database, parse the newlines for correct display in HTML/emails etc."""
+        # Empty for now, but could do some processing here
+        return string_from_database
+
+    @staticmethod
+    def _generate_used_fields(template_body):
+        """Generate the dictionary of the fields used in a specific template"""
+        fields_used = {"target": [], "user": []}
+        # To be implemented - most likely using regex to match "{t[]}" and "{u[]}"
+        return fields_used
+
+    def _validate_target(self):
+        if self.target is None:
+            raise AttributeError("Target not set for this template.")
+        else:
+            for key in self.fields_used["target"]:
+                if key in self.target:
+                    pass
+                else:
+                    raise KeyError("Template requires key not present in target info.")
+
+    def _validate_user_info(self, user_info):
+        for key in self.fields_used["user"]:
+            if key in user_info:
+                pass
+            elif key == "address":
+                # Handle people who don't give their address
+                user_info["address"] = "[INPUT YOUR ADDRESS HERE]"
+            else:
+                raise KeyError("Template requires key not present in user info.")
+        return user_info
 
     def __str__(self):
         return str([self.subject, self.body])
 
     def set_target(self, name, email, constituency=None):
-
         self.target = {
             "name": name,
             "email": email,
@@ -39,24 +122,17 @@ class EmailTemplate:
         if self.filled:
             # Already filled, so do not need to fill again
             return self.filled
-        if self.target is None:
-            # Target not set, so cannot fill
-            self.filled = False
-            return self.filled
-        try:
-            address = user_info["address"]
-        except:
-            address = "[ENTER YOUR ADDRESS HERE]"
-            user_info["address"] = address
-        self.body = self.body.format(t=self.target, u=user_info)
+        self._validate_target()
+        validated_user_info = self._validate_user_info(user_info)
+        self.body = self.body.format(t=self.target, u=validated_user_info)
         self.filled = True
         return self.filled
 
 
-# For Reference this is what I would expect our information about the user and target to look like
+# Reference dictionaries for user and target info
 user_info = {
     "name": "John Smith",
-    "address": "1 Test Road, Somewhere,",
+    "address": "1 Test Road, Somewhere, AB1 2CD",
 }
 target_info = {
     "name": "Big Bad Government",
@@ -64,166 +140,84 @@ target_info = {
     "email": "bigbadboi@hotmail.co.uk",
 }
 
-mp_police = EmailTemplate(
-    subject="Suspension of Exportation of Policing Equipment to the US",
-    body="""
-Dear {t[name]},
+# This dictionary represents how a template will be stored in the database
+example_template = {
+    # Subject field: To be entered in the subject field of mailto and gmail links
+    "subject": "Justice for an Email Template Example",
+    # Body field: Content of the template including dictionary lookups for auto-filling later
+    "body": "dear {t[name]},\nLots of complex ideas and thoughts\n expressed well (handle newlines) from: {u[name]} {u[address]}",
+    # Name of the template: ideally 3-4 words max to allow a quick description of this template, may be the same as the subject line of the email for some templates.
+    # This will be used to check if template already exists so AVOID RENAMING TEMPLATES
+    "name": "Three-Four Word description",
+    # List of topics that this email tackles,
+    # This will allow filtering templates by topic at a general level (eg "All Templates on Racial Injustice") and on a more specific level (eg "Belly Mujinga")
+    "topics": ["Wide, overarching issue", "Specific topic of this template"],
+    # URL linking to the author of the template: "This template was written by [This Person]("template_author_url")"
+    "author_url": "https://twitter.com/ACoolGuy/status/emailtemplateidea",
+    # URL linking to more information on this campaign: "More info for this campaign can be found [here]("template_more_info_url")"
+    "more_info_url": "https://campaign-website.com",
+    # The target the template is addressed to.
+    # The "target" field is only set if the target for the email is known before getting user data, i.e. always the same person.
+    # If the "target" field is unset, the target relies on user input, and thus we assume the target must be the local MP of the website user.
+    # In the future we may want to store targets separately, however for now we store their information as a dictionary under the target field of the template.
+    "target": {
+        # "Name" and "Email" are the only required fields for targets at the moment, however in the future more complex templates may require attributes such as "department"
+        "name": "CEO of Bad Company",
+        "email": "ceo@company.com",
+    },
+    # CC- carbon copy addresses: A list of emails to put in the cc field of the email, we may want to extend this later, for example to include LOCALMP or some other flag to allow an MP to be copied into an email to a head of a government department.
+    "cc": ["anotherperson@company.com"],
+    # The attributes of the user and target dictionaries which the body of the template requires to be filled correctly.
+    # Used for validation of the template against provided user & target info
+    "fields_used": {"target": ["name"], "user": ["name", "address"],},
+    # Flag setting template visibility
+    # Later when private campaigns are implemented we won't want to serve every template on the homepage - this flag allows us to disable templates without deleting them.
+    "public": True,
+}
 
 
-My name is {u[name]} and I am a resident of {t[constituency]}, at {u[address]}.
-
-I am writing to you today to implore you to put pressure on the government to stop the exportation of tear gas, rubber bullets and riot shields to the United States and to condemn Trump's use of force against his own citizens.
-After the shocking footage of the police and the national guard using excessive force against Black Lives Matter protesters across the United States, the UK should immediately stop all policing and security equipment export to the US where there is a clear risk of further misuse. This is something the UK is obligated to do under its own laws.
-Given the evidence emerging from multiple US cities, there is a very real risk of UK-manufactured tear gas or rubber bullets being used against George Floyd protesters in dangerous and highly inappropriate ways - ministers must respond to this.
-Ministers should be making detailed case by case assessments of any requests for equipment from individual US police forces – withholding exports from any that have clearly acted irresponsible during the current crisis. The UK has an obscene track record of looking the other way when UK arms and security equipment is misused overseas. Now is the time to change that.
-In addition to immediate suspension of UK sales of tear gas, riot shields and rubber bullets to the US, the UK Government should condemn Trump's use of force against his own citizens. The behaviour he has exhibited is anti-democratic and cruel. It sets a dangerous precedent and the UK government must acknowledge this.
-In short, my requests to you are:
-
-
-    - Immediate stopping of UK sales of teargas, riot shield and rubber bullets to the US
-    - Condemnation of Trump's use of force against his own citizens
-
-
-Thank you for your time. Please respond to this email as soon as you see fit.
-Regards,
-
-{u[name]}
-    """,
-)
-
-
-gavinwilliamson_email = EmailTemplate(
-    subject="Make Black histories mandatory in the national curriculum",
-    body="""
-Dear {t[name]},
-
-
-As supporters of The Black Curriculum, we are dismayed by the events of the last few weeks which have disproportionately affected Black people in the UK - exacerbated by Covid19, and the subsequent lack of response by those in authority. Thousands of us, the British voting public are grief stricken and concerned about the existing status-quo in the UK, which disregards the lives and contributions of Black British people. We would like to bring to your attention some of the structural inequalities in the UK, especially pertaining to education and the national curriculum.
-As you are aware, the national curriculum excludes Black histories throughout, and omits the vast contributions Black people have made to the UK. As a result, young people who learn from the national curriculum are not given a full or accurate version of British history, which limits their opportunities and futures in an increasingly diverse landscape. Despite numerous calls over the years to reform the national curriculum to incorporate Black histories, these requests have been denied. Learning Black history should not be a choice but should be mandatory. Our curriculum should not be reinforcing the message that a sizeable part of the British population are not valued.
-Black people have been in Britain since Roman times, have contributed to and shaped the foundation of our society. Therefore, we are asking you to specifically include Black histories on the national curriculum from KS1 - KS4 to include Black British histories across different subject areas, including History, Citizenship, English and PSHE. By doing so, you can invest in the lives and opportunities of all young people across the UK to become fully rounded citizens and create a better, fairer society. This is in line with the DfE Strategy’s first principle as highlighted in 2015-2020 World-class Education and Care: “Our first principle is to ensure each policy puts children and young people first. We must not let anything detract from improving the lives and opportunities of those who rely on the education and children social care systems.” – p.11, DfE strategy 2015-2020
-
-The Black Curriculum is demanding that you work with them to adequately incorporate Black British history into the national curriculum and to fulfil your goals of British education truly being able to help the government’s “commitments to social justice and economic growth.”
-Will you meet with the leaders of the Black Curriculum? They are ready and waiting for your response.
-
-With thanks,
-
-{u[name]}""",
-)
-gavinwilliamson_email.set_target(
-    name="Secretary of State for Education", email="gavin.williamson.mp@parliament.uk"
-)
-
-belly_mujinga_mp = EmailTemplate(
-    subject="Justice for Belly Mujinga",
-    body="""
-Dear {t[name]},
-
-My name is {u[name]} and I am a resident of {t[constituency]}, at {u[address]}.
-
-I write further to my previous email regarding Black Lives Matter with a specific demand for justice for Belly Mujinga, a railway ticket office worker who contracted COVID-19 and subsequently died. I am sure you are aware that Mujinga, a key worker, was spat on by a member of the public claiming he was infectious on March 21.
-
-Despite this event taking place, a spokesperson for British Transport Police has recently stated that they will take no further action into the case, given that the “tragic death of Belly Mujinga was not a consequence of this incident.”
-
-However, in Glasgow, a man who spat at a police officer and joked about coronavirus has been jailed for twelve months.
-
-I recognise that there may be legal differences between each of the four nations, but it is unconscionable to me that there is such a gulf between the consequences of these two actions. Regardless of whether illness may or may not be attributed to the assault, it is an assault nonetheless, and an assault that in the case of Belly Mujinga has not been given due weight.
-
-I find this especially troubling following the report published into disproportionate BAME deaths due to COVID-19, and ask whether Belly Mujinga - a Congolese woman with underlying health issues, who was reportedly scared for her life - was a victim of a poor response to the coronavirus pandemic on the part of British authorities.
-
-I urge the UK government to seek to reopen the investigation into the assault on Belly Mujinga.
-
-Yours sincerely,
-
-{u[name]}""",
-)
-
-belly_mujinga_govia = EmailTemplate(
-    subject="Justice for Belly Mujinga",
-    body="""
-Dear {t[name]},
-
-I am writing to you in regards to the recent death of Belly Mujinga, who worked for Govia Thameslink Railway. Her death follows after an assault was carried out on 21st March in which her and colleagues were spat at and coughed on during their shift at London Victoria Station.
-
-As I am sure you are aware, it was revealed on 29th May that The British Transport Police ruled that they believed there was no link between the act of assault and her death and stated that ‘no further action will be taken’, closing the case. In spite of this Ms. Mujinga’s passing on 5th April comes just two weeks after the assault had taken place and after several days having been admitted to hospital and testing positive for COVID-19.
-
-Following the outcome in regards to Ms. Mujinga’s death and The British Transport Police’s dismissal of the case, I urge you as CEO of Govia Thameslink Railway, to take action on her behalf and to that of her loved ones following her death. As an essential worker, Ms. Mujinga was failed by the Govia Thameslink Rail to be protected after she had expressed concerns for her wellbeing due to respiratory issues. Ms. Mujinga made appeals to work away from crowds at the busy station due to there being no PPE provided for railway workers, her concerns were inadequately dismissed.
-
-In spite of the assault carried out and Ms. Mujinga’s passing it was reported by The Independent in an article released on 14th May by a worker at London Victoria station that “There’s not much being done to check all the staff, today is the first day we have had masks.” Going forward, it shows that you have not prioritised the protection and the safety of your staff to prevent such an act happening again in the future.
-
-So I ask, why did you ignore Belly’s requests to work away from crowds during the pandemic as she had underlying health issues?
-
-Further, why did it take weeks for Govia to surrender the CCTV footage to the police?
-
-As a concerned individual I urge you to recognise the needs of more effective regulations and protection of railway workers at Govia Thameslink Rail during this time and for an assault similar to that of Ms Mujinga which effectively cost her life does not take place again.
-
-Until responsible actions are taken to honour the death of Belly and prevent the future assault of your workers and you take full responsibility for your role in Belly's murder, I have decided to boycott Southern Rail, Gatwick Express, Great Northern and Thameslink.
-
-Regards,
-
-{u[name]}""",
-)
-belly_mujinga_govia.set_target(
-    name="Patrick Verwer", email="Patrick.Verwer@gtrailway.com"
-)
-
-# Re: The murder of a 12-year-old schoolgirl, Shukri Yahya Abdi.
-shukri_abdi = EmailTemplate(
-    subject="Justice For Shukri Abdi",
-    body="""
-Dear {t[name]},
-
-As your constituent, I am writing to call upon you to take action against Hazel Wood High School for concerning patterns of failures to protect both staff and pupils from bullying, resulting in deaths; and Greater Manchester Police for failing to properly investigate the murder of Shukri Abdi due to institutionalised racism. We demand justice for Shukri Abdi.
-
-The body of Shukri, who first came to the UK in January 2017 as a refugee seeking a better life, was found in the River Irwell in Bury, Greater Manchester in June 2019. An inquest heard that Shukri had been threatened by her class peer/s and told: “if you don’t get into the water, I’m going to kill you”. I am utterly beyond outraged, saddened and disappointed that children in our society can be so badly let down and failed. Shukri has been described as an “angelic, funny and kind-hearted little girl” that had much to offer.
-
-There are very concerning patterns of failure to meet adequate safeguarding measures at Hazel Wood High School, who has since rebranded from Broad Oak Sports College. The latest Ofsted report concluded that the school was “inadequate” and has thus since been put on “special measures” by Her Majesty’s Chief Inspector, per section 44(1) of the Education Act 2005. Shurki has been woefully failed by Hazel Wood High School. Their incompetence can be argued to have played a key role in the murder of Shukri. Additionally, Manchester Evening News reported that in 2015 a “senior teacher, Caroline Bailey, at Broad Oak Sports College” (Hazel Wood High School) had committed suicide; an inquest heard that this was, yet again, due to “strategic bullying” from co-workers within the school. I urge you to raise these concerning patterns of failure to safeguard against bullying, resulting in deaths, at Hazel Wood High School, with the Secretary of State for Education, Gavin Williamson.
-
-Furthermore, Greater Manchester Police (GMP) must also be investigated for their ineptitude in investigating this murder, no less a sign of institutionalised racism that has failed yet another black life. Reports show that the Officers at the scene of the murder took witness statements from only two out of four present at Shukri’s death. Her murder was ruled by GMP to be an accident within two weeks. One can argue that Shukri’s murder has not been properly investigated due to her ethnic background and, therefore, has led to my loss of confidence in the impartiality of the GMP in serving to protect and uphold justice for all citizens. I urge you to raise these concerns with the Mayor of Manchester, Andy Burnham.
-
-Moreover, Shukri’s death can also be placed in a wider landscape of institutional racism within modern-day Britain. Yvette Cooper, Labour MP and chair of the home affairs select committee damned the “deeply unfair shambles” of how asylum seekers are accommodated. The Guardian analysis of Home Office data found that “more than half of all asylum seekers (57%) housed by the government are done so in the poorest third of the country”. I trust that we can agree that we must do more to support the most vulnerable in our society and that these statistics are wholly unacceptable.
-
-As you are well aware of the global outrage against injustices rooted in systemic and perpetual institutionalised racism, I leave you with the words of human rights activist and organiser of the protests demanding justice for Shukri Abdi, Bashir Ibrahim: “she was failed when she was alive and she’s still being failed now as she’s dead”.
-
-I look forward to your urgent response,
-
-Yours sincerely,
-
-{u[name]}
-""",
-)
-
-
-def get_existing_templates():
+def get_existing_templates(query=None, only_public=True):
     """Grab all the template options that exist so far"""
-    """
-    IMPORTANT: Gavin Williamson template removed until we can find a way to contanct him via his preferred method for enquiries about educations
-    """
-    # Returns an array of JSON objects from the email_templates collection.
-    emails = mongo.get_all("email_templates")
-    templates = []
 
+    # Returns an array of JSON objects from the email_templates collection.
+    if query is None:
+        # Default is get all of the email templates
+        emails = mongo.get_all("email_templates")
+    else:
+        # However if a query is specified, only return templates matching the query
+        emails = mongo.get_all_matching("email_templates", query)
+
+    templates = []
     for e in emails:
         # Iterate through emails and create EmailTemplate objects
-        templates.append(
-            EmailTemplate(subject=e["email_subject"], body=e["email_body"])
-        )
+        if only_public:
+            if e["public"]:
+                # Only append public templates
+                templates.append(EmailTemplate(**e))
+        else:
+            templates.append(EmailTemplate(**e))
 
-    # Need to fill Target fields on some templates
     return templates
 
 
-def add_new_template(reference, subject, body, target=None):
-    # Check if reference already exists, and update if so.
-    if mongo.get_one("email_templates", {"email_reference": reference}):
-        return False
+def pre_database_template_validation(**template_dict):
+    """Check the template dictionary is valid before sending to database"""
+    return template_dict
+
+
+def add_or_update_template(**t):
+    # Check if template using this name already exists, and update if so.
+    template_dict = pre_database_template_validation(t)
+    existing_template = mongo.get_one(
+        "email_templates", {"name": template_dict["name"]}
+    )
+    if existing_template:
+        # Update existing template
+        mongo.update_one(
+            "email_templates", {"name": template_dict["name"]}, template_dict
+        )
+        return True
     else:
-        # Parse body to change new lines to \n.
-        # I don't know why the below works, but it really do work.
-        body = body.replace("\n", "\n")
-        template_row = {
-            "email_reference": reference,
-            "email_subject": subject,
-            "email_body": body,
-        }
-        mongo.insert_one("email_templates", template_row)
+        # Template doesn't exist so create this template
+        mongo.insert_one("email_templates", template_dict)
         return True

--- a/emailtemplates.py
+++ b/emailtemplates.py
@@ -3,8 +3,9 @@ Object representation of EmailTemplates, plus functions to store and retrieve te
 
 Written by David Swarbrick (davidswarbrick) 2020
 """
-from database import myDb
 import logging
+import re
+from database import myDb
 
 
 # Instantiate the db connection:
@@ -12,6 +13,9 @@ mongo = myDb()
 
 # Instantiate logging:
 log = logging.getLogger("app")
+
+ALLOWED_USER_FIELDS = ["name", "address"]
+ALLOWED_TARGET_FIELDS = ["name", "constituency", "email"]
 
 
 class EmailTemplate:
@@ -24,13 +28,21 @@ class EmailTemplate:
             self.subject = email_template_dict["subject"]
             self.body = self._parse_newlines_from_db(email_template_dict["body"])
             self.name = email_template_dict["name"]
-            self.fields_used = email_template_dict["fields_used"]
         except KeyError:
             # If we cannot get a subject and body of the template it is unusable
             log.debug("Could not decode subject, body and used fields for the template")
             raise
 
-        # Second, attempt to get other details, and set default values if unavailable
+        # If fields_used is already set, use those, otherwise generate new fields_used dict.
+        try:
+            self.fields_used = email_template_dict["fields_used"]
+        except KeyError:
+            self.fields_used = self._generate_used_fields(self.body)
+
+        # Check this is a valid template
+        self._validate_template_body(self.body, self.fields_used)
+
+        # Attempt to get other details, and set default values if unavailable
 
         try:
             self.topics = email_template_dict["topics"]
@@ -55,9 +67,14 @@ class EmailTemplate:
 
         try:
             self.target = email_template_dict["target"]
+
         except KeyError:
             # If target is None that means we are setting the target from MP data
             self.target = None
+
+        # If a target is set, make sure it is valid
+        if self.target:
+            self._validate_target()
 
         try:
             self.public = email_template_dict["public"]
@@ -83,8 +100,38 @@ class EmailTemplate:
     def _generate_used_fields(template_body):
         """Generate the dictionary of the fields used in a specific template"""
         fields_used = {"target": [], "user": []}
-        # To be implemented - most likely using regex to match "{t[]}" and "{u[]}"
+        # Using regex to match "{t[]}" and "{u[]}"
+        # (?<={t\[)\w+(?=\]}) -- positive look behind for {t[, match a word that ends with ]}
+        target_searcher = re.compile(r"(?<={t\[)\w+(?=\]})")
+        user_searcher = re.compile(r"(?<={u\[)\w+(?=\]})")
+        # Use a set to make sure there is only one of each item, but return a list to the dictionary
+        fields_used["target"] = list(set(target_searcher.findall(template_body)))
+        fields_used["user"] = list(set(user_searcher.findall(template_body)))
+
         return fields_used
+
+    @staticmethod
+    def _validate_template_body(template_body, fields_used):
+        """Check the template body matches the fields_used dictionary, and that all fields are legal choices."""
+
+        # Generate the fields the template requires to check the supplied fields are correct
+        template_fields_used = EmailTemplate._generate_used_fields(template_body)
+
+        # Check the fields used in the template matches those we expect to be used:
+        if set(fields_used["target"]) != set(template_fields_used["target"]):
+            raise KeyError(
+                "Supplied Target keys do not match Target fields in template"
+            )
+        if set(fields_used["user"]) != set(template_fields_used["user"]):
+            raise KeyError("Supplied User keys do not match User fields in template")
+
+        # Check the keys against the legal keys (set above)
+        for key in fields_used["target"]:
+            if key not in ALLOWED_TARGET_FIELDS:
+                raise KeyError("Illegal Target Key Identified: {}".format(key))
+        for key in fields_used["user"]:
+            if key not in ALLOWED_USER_FIELDS:
+                raise KeyError("Illegal User Key Identified: {}".format(key))
 
     def _validate_target(self):
         if self.target is None:
@@ -129,53 +176,6 @@ class EmailTemplate:
         return self.filled
 
 
-# Reference dictionaries for user and target info
-user_info = {
-    "name": "John Smith",
-    "address": "1 Test Road, Somewhere, AB1 2CD",
-}
-target_info = {
-    "name": "Big Bad Government",
-    "constituency": "Westminster",
-    "email": "bigbadboi@hotmail.co.uk",
-}
-
-# This dictionary represents how a template will be stored in the database
-example_template = {
-    # Subject field: To be entered in the subject field of mailto and gmail links
-    "subject": "Justice for an Email Template Example",
-    # Body field: Content of the template including dictionary lookups for auto-filling later
-    "body": "dear {t[name]},\nLots of complex ideas and thoughts\n expressed well (handle newlines) from: {u[name]} {u[address]}",
-    # Name of the template: ideally 3-4 words max to allow a quick description of this template, may be the same as the subject line of the email for some templates.
-    # This will be used to check if template already exists so AVOID RENAMING TEMPLATES
-    "name": "Three-Four Word description",
-    # List of topics that this email tackles,
-    # This will allow filtering templates by topic at a general level (eg "All Templates on Racial Injustice") and on a more specific level (eg "Belly Mujinga")
-    "topics": ["Wide, overarching issue", "Specific topic of this template"],
-    # URL linking to the author of the template: "This template was written by [This Person]("template_author_url")"
-    "author_url": "https://twitter.com/ACoolGuy/status/emailtemplateidea",
-    # URL linking to more information on this campaign: "More info for this campaign can be found [here]("template_more_info_url")"
-    "more_info_url": "https://campaign-website.com",
-    # The target the template is addressed to.
-    # The "target" field is only set if the target for the email is known before getting user data, i.e. always the same person.
-    # If the "target" field is unset, the target relies on user input, and thus we assume the target must be the local MP of the website user.
-    # In the future we may want to store targets separately, however for now we store their information as a dictionary under the target field of the template.
-    "target": {
-        # "Name" and "Email" are the only required fields for targets at the moment, however in the future more complex templates may require attributes such as "department"
-        "name": "CEO of Bad Company",
-        "email": "ceo@company.com",
-    },
-    # CC- carbon copy addresses: A list of emails to put in the cc field of the email, we may want to extend this later, for example to include LOCALMP or some other flag to allow an MP to be copied into an email to a head of a government department.
-    "cc": ["anotherperson@company.com"],
-    # The attributes of the user and target dictionaries which the body of the template requires to be filled correctly.
-    # Used for validation of the template against provided user & target info
-    "fields_used": {"target": ["name"], "user": ["name", "address"],},
-    # Flag setting template visibility
-    # Later when private campaigns are implemented we won't want to serve every template on the homepage - this flag allows us to disable templates without deleting them.
-    "public": True,
-}
-
-
 def get_existing_templates(query=None, only_public=True):
     """Grab all the template options that exist so far"""
 
@@ -202,6 +202,12 @@ def get_existing_templates(query=None, only_public=True):
 
 def pre_database_template_validation(**template_dict):
     """Check the template dictionary is valid before sending to database"""
+    try:
+        et = EmailTemplate(**template_dict)
+
+    except KeyError as k:
+        log.debug("Template invalid: ", k)
+        raise
     return template_dict
 
 

--- a/emailtemplates.py
+++ b/emailtemplates.py
@@ -145,11 +145,11 @@ class EmailTemplate:
 
     def _validate_user_info(self, user_info):
         for key in self.fields_used["user"]:
-            if key in user_info:
-                pass
-            elif key == "address":
+            if key == "address" and user_info[key] is None:
                 # Handle people who don't give their address
                 user_info["address"] = "[INPUT YOUR ADDRESS HERE]"
+            if key in user_info:
+                pass
             else:
                 raise KeyError("Template requires key not present in user info.")
         return user_info
@@ -190,12 +190,13 @@ def get_existing_templates(query=None, only_public=True):
     templates = []
     for e in emails:
         # Iterate through emails and create EmailTemplate objects
+        et = EmailTemplate(**e)
         if only_public:
-            if e["public"]:
+            if et.public:
                 # Only append public templates
-                templates.append(EmailTemplate(**e))
+                templates.append(et)
         else:
-            templates.append(EmailTemplate(**e))
+            templates.append(et)
 
     return templates
 

--- a/emailtemplates.py
+++ b/emailtemplates.py
@@ -70,7 +70,7 @@ mp_police = EmailTemplate(
 Dear {t[name]},
 
 
-My name is {u[name]} and I am a resident of {t[constituency]}, at {t[address]}.
+My name is {u[name]} and I am a resident of {t[constituency]}, at {u[address]}.
 
 I am writing to you today to implore you to put pressure on the government to stop the exportation of tear gas, rubber bullets and riot shields to the United States and to condemn Trump's use of force against his own citizens.
 After the shocking footage of the police and the national guard using excessive force against Black Lives Matter protesters across the United States, the UK should immediately stop all policing and security equipment export to the US where there is a clear risk of further misuse. This is something the UK is obligated to do under its own laws.
@@ -118,7 +118,7 @@ belly_mujinga_mp = EmailTemplate(
     body="""
 Dear {t[name]},
 
-My name is {u[name]} and I am a resident of {t[constituency]}, at {t[address]}.
+My name is {u[name]} and I am a resident of {t[constituency]}, at {u[address]}.
 
 I write further to my previous email regarding Black Lives Matter with a specific demand for justice for Belly Mujinga, a railway ticket office worker who contracted COVID-19 and subsequently died. I am sure you are aware that Mujinga, a key worker, was spat on by a member of the public claiming he was infectious on March 21.
 

--- a/emailtemplates.py
+++ b/emailtemplates.py
@@ -213,7 +213,7 @@ def pre_database_template_validation(**template_dict):
 
 def add_or_update_template(**t):
     # Check if template using this name already exists, and update if so.
-    template_dict = pre_database_template_validation(t)
+    template_dict = pre_database_template_validation(**t)
     existing_template = mongo.get_one(
         "email_templates", {"name": template_dict["name"]}
     )

--- a/mpdetails.py
+++ b/mpdetails.py
@@ -1,0 +1,18 @@
+import urllib.request, json
+from database import myDb
+
+# Instantiate the db
+mongo = myDb()
+
+
+def get_mp_details(postcode):
+    url_base = "http://api.postcodes.io/postcodes/"
+    with urllib.request.urlopen(url_base + postcode) as url:
+        data = json.loads(url.read().decode())
+        if data["status"] == 200:
+            # Create query from the data retrieved from postcodes.io
+            query = {"constituency": data["result"]["parliamentary_constituency"]}
+        else:
+            raise KeyError("No postcode found!")
+
+    return mongo.get_one("mp_email_list", query)

--- a/scripts/retrieve_mp_data.py
+++ b/scripts/retrieve_mp_data.py
@@ -6,15 +6,6 @@ from urllib.error import HTTPError
 
 
 ###################### These aren't used anymore but may be used for a future thing if MPs aren't in the database ###############################
-def validatePostcodeApi(postcode):
-    url_base = "http://api.postcodes.io/postcodes/"
-    postcode = postcode.replace(" ", "").upper()
-    try:
-        with urllib.request.urlopen(url_base + postcode) as url:
-            data = json.loads(url.read().decode())
-            return data["status"] == 200
-    except HTTPError:
-        return False
 
 
 def getGovDetails(postcode):

--- a/scripts/retrieve_mp_data.py
+++ b/scripts/retrieve_mp_data.py
@@ -1,0 +1,154 @@
+import urllib.request, json
+import requests
+from bs4 import BeautifulSoup
+import csv
+from urllib.error import HTTPError
+
+
+###################### These aren't used anymore but may be used for a future thing if MPs aren't in the database ###############################
+def validatePostcodeApi(postcode):
+    url_base = "http://api.postcodes.io/postcodes/"
+    postcode = postcode.replace(" ", "").upper()
+    try:
+        with urllib.request.urlopen(url_base + postcode) as url:
+            data = json.loads(url.read().decode())
+            return data["status"] == 200
+    except HTTPError:
+        return False
+
+
+def getGovDetails(postcode):
+
+    url_base = "http://api.postcodes.io/postcodes/"
+    with urllib.request.urlopen(url_base + postcode) as url:
+        data = json.loads(url.read().decode())
+        if data["status"] == 200:
+            topdata = data["result"]
+        else:
+            print(f"Invalid postcode {postcode}")
+            raise KeyError("No postcode found!")
+
+    MPurl = (
+        "http://lda.data.parliament.uk/commonsmembers.json?_view=members&_pageSize=2097&_page=0&constituency.label="
+        + "%20".join(topdata["parliamentary_constituency"].split(" "))
+    )
+
+    with urllib.request.urlopen(MPurl) as url:
+        MPdata = json.loads(url.read().decode())
+
+        for possibleMP in MPdata["result"]["items"]:
+            MPid = (possibleMP["_about"]).split("/")[-1]
+            print("Checking MP: {}".format(possibleMP["fullName"]))
+
+            try:
+                MPurl = "https://members.parliament.uk/member/{}/contact".format(MPid)
+                MPemails = emailExtractor(MPurl)  # MP email (in a list)
+                assert len(MPemails) > 0
+                # Quick hack to only return one email
+                MPemail = MPemails[0]
+
+                myward = topdata["admin_ward"]  # User's ward
+                MPname = possibleMP["fullName"]["_value"]
+                print("Found correct MP: {}. Email: {} ".format(MPname, MPemail))
+                break
+            except:
+                pass
+
+    return {"ward": myward, "MPemail": MPemail, "MPname": MPname}
+
+
+def emailExtractor(urlString):
+    emailList = []
+    getH = requests.get(urlString)
+    h = getH.content
+    soup = BeautifulSoup(h, "html.parser")
+    mailtos = soup.select("a[href^=mailto]")
+    for i in mailtos:
+        href = i["href"]
+        try:
+            str1, str2 = href.split(":")
+        except ValueError:
+            break
+
+        emailList.append(str2)
+    return emailList
+
+
+######################### End of (temporarily) useless functions
+
+
+def convert_party(party):
+    switcher = {
+        "Conservative": 1,
+        "Labour": 2,
+        "Scottish National Party": 3,
+        "Liberal Democrats": 4,
+        "Independent": 5,
+        "Plaid Cymru": 6,
+        "Social Democratic Party": 7,
+        "Social Democratic & Labour Party": 7,
+        "Alliance": 8,
+        "Green Party": 9,
+        "Democratic Unionist Party": 10,
+        "Sinn Féin": 11,
+        "Speaker": 12,
+    }
+    return switcher.get(party)
+
+
+def retrieve_mp_data():
+
+    MPdata = {}
+
+    MPurl = "http://lda.data.parliament.uk/commonsmembers.json?_view=members&_pageSize=3000&_page=0"
+
+    # Get the list of MP JSON Data
+    with urllib.request.urlopen(MPurl) as url:
+        MPlist = json.loads(url.read().decode())["result"]["items"]
+
+    # Iterate over each MP
+    for mp in MPlist:
+        # Get each relevant field
+        constituency = mp["constituency"]["label"]["_value"]
+        party = mp["party"]["_value"]
+        # Format the name nicely!
+        fullname = (
+            mp["givenName"]["_value"].strip() + " " + mp["familyName"]["_value"].strip()
+        )
+        real_fullname = mp["fullName"]["_value"].strip()
+        # id = (mp["_about"]).split("/")[-1]
+
+        # Create an entry for the MP in the dict
+        MPdata[fullname] = [constituency, real_fullname, party]
+
+    # Open the CSV file containing the email.
+    with open("190391mpl.csv") as csv_file:
+        csv_reader = csv.reader(csv_file)
+        for row in csv_reader:
+            full_name = (
+                row[0].replace('"', "").strip() + " " + row[2].replace('"', "").strip()
+            )
+            try:
+                MPdata[full_name].append(row[3].replace(" ", "").replace('"', ""))
+            except:
+                pass
+
+    MPdata_formatted = []
+    errors = 0
+    count = 1
+    for key, value in MPdata.items():
+        try:
+            MPdata_formatted.append(
+                {
+                    "_id": count,
+                    "name": value[1],
+                    "email": value[3],
+                    "constituency": value[0],
+                    "party": convert_party(value[2]),
+                }
+            )
+            count += 1
+        except:
+            errors += 1
+            pass
+    return MPdata_formatted

--- a/submit_old_templates.py
+++ b/submit_old_templates.py
@@ -27,6 +27,7 @@ Regards,
     """,
     "name": "Suspend Police Equipment Exports",
     "topics": ["black-lives-matter"],
+    "public": True,
 }
 
 
@@ -79,6 +80,7 @@ I urge the UK government to seek to reopen the investigation into the assault on
 Yours sincerely,
 
 {u[name]}""",
+    "public": True,
 }
 
 
@@ -107,6 +109,7 @@ Until responsible actions are taken to honour the death of Belly and prevent the
 Regards,
 
 {u[name]}""",
+    "public": True,
 }
 belly_mujinga_govia["target"] = {
     "name": "Patrick Verwer",
@@ -138,6 +141,7 @@ Yours sincerely,
 
 {u[name]}
 """,
+    "public": True,
 }
 
 for t in [

--- a/submit_old_templates.py
+++ b/submit_old_templates.py
@@ -1,4 +1,4 @@
-from emailtemplates import EmailTemplate, add_or_update_template
+from emailtemplates import add_or_update_template
 
 mp_police = {
     "subject": "Suspension of Exportation of Policing Equipment to the US",
@@ -34,6 +34,7 @@ Regards,
 
 
 gavinwilliamson_email = {
+    "name": "National Curriculum Change",
     "subject": "Make Black histories mandatory in the national curriculum",
     "body": """
 Dear {t[name]},
@@ -56,6 +57,7 @@ gavinwilliamson_email["target"] = {
 }
 
 belly_mujinga_mp = {
+    "name": "Belly Mujinga - MP",
     "subject": "Justice for Belly Mujinga",
     "body": """
 Dear {t[name]},
@@ -81,6 +83,7 @@ Yours sincerely,
 
 
 belly_mujinga_govia = {
+    "name": "Belly Mujinga - Govia",
     "subject": "Justice for Belly Mujinga",
     "body": """
 Dear {t[name]},
@@ -112,6 +115,7 @@ belly_mujinga_govia["target"] = {
 
 
 shukri_abdi = {
+    "name": "Justice for Shukri Abdi",
     "subject": "Justice For Shukri Abdi",
     "body": """
 Dear {t[name]},
@@ -143,4 +147,4 @@ for t in [
     belly_mujinga_govia,
     shukri_abdi,
 ]:
-    add_or_update_template(t)
+    add_or_update_template(**t)

--- a/submit_old_templates.py
+++ b/submit_old_templates.py
@@ -1,0 +1,144 @@
+from emailtemplates import EmailTemplate, add_or_update_template
+
+mp_police = {
+    "subject": "Suspension of Exportation of Policing Equipment to the US",
+    "body": """
+Dear {t[name]},
+
+
+My name is {u[name]} and I am a resident of {t[constituency]}, at {u[address]}.
+
+I am writing to you today to implore you to put pressure on the government to stop the exportation of tear gas, rubber bullets and riot shields to the United States and to condemn Trump's use of force against his own citizens.
+After the shocking footage of the police and the national guard using excessive force against Black Lives Matter protesters across the United States, the UK should immediately stop all policing and security equipment export to the US where there is a clear risk of further misuse. This is something the UK is obligated to do under its own laws.
+Given the evidence emerging from multiple US cities, there is a very real risk of UK-manufactured tear gas or rubber bullets being used against George Floyd protesters in dangerous and highly inappropriate ways - ministers must respond to this.
+Ministers should be making detailed case by case assessments of any requests for equipment from individual US police forces – withholding exports from any that have clearly acted irresponsible during the current crisis. The UK has an obscene track record of looking the other way when UK arms and security equipment is misused overseas. Now is the time to change that.
+In addition to immediate suspension of UK sales of tear gas, riot shields and rubber bullets to the US, the UK Government should condemn Trump's use of force against his own citizens. The behaviour he has exhibited is anti-democratic and cruel. It sets a dangerous precedent and the UK government must acknowledge this.
+In short, my requests to you are:
+
+
+    - Immediate stopping of UK sales of teargas, riot shield and rubber bullets to the US
+    - Condemnation of Trump's use of force against his own citizens
+
+
+Thank you for your time. Please respond to this email as soon as you see fit.
+Regards,
+
+{u[name]}
+    """,
+}
+
+
+# IMPORTANT: Gavin Williamson template removed until we can find a way to contanct him via his preferred method for enquiries about educations
+
+
+gavinwilliamson_email = {
+    "subject": "Make Black histories mandatory in the national curriculum",
+    "body": """
+Dear {t[name]},
+
+
+As supporters of The Black Curriculum, we are dismayed by the events of the last few weeks which have disproportionately affected Black people in the UK - exacerbated by Covid19, and the subsequent lack of response by those in authority. Thousands of us, the British voting public are grief stricken and concerned about the existing status-quo in the UK, which disregards the lives and contributions of Black British people. We would like to bring to your attention some of the structural inequalities in the UK, especially pertaining to education and the national curriculum.
+As you are aware, the national curriculum excludes Black histories throughout, and omits the vast contributions Black people have made to the UK. As a result, young people who learn from the national curriculum are not given a full or accurate version of British history, which limits their opportunities and futures in an increasingly diverse landscape. Despite numerous calls over the years to reform the national curriculum to incorporate Black histories, these requests have been denied. Learning Black history should not be a choice but should be mandatory. Our curriculum should not be reinforcing the message that a sizeable part of the British population are not valued.
+Black people have been in Britain since Roman times, have contributed to and shaped the foundation of our society. Therefore, we are asking you to specifically include Black histories on the national curriculum from KS1 - KS4 to include Black British histories across different subject areas, including History, Citizenship, English and PSHE. By doing so, you can invest in the lives and opportunities of all young people across the UK to become fully rounded citizens and create a better, fairer society. This is in line with the DfE Strategy’s first principle as highlighted in 2015-2020 World-class Education and Care: “Our first principle is to ensure each policy puts children and young people first. We must not let anything detract from improving the lives and opportunities of those who rely on the education and children social care systems.” – p.11, DfE strategy 2015-2020
+
+The Black Curriculum is demanding that you work with them to adequately incorporate Black British history into the national curriculum and to fulfil your goals of British education truly being able to help the government’s “commitments to social justice and economic growth.”
+Will you meet with the leaders of the Black Curriculum? They are ready and waiting for your response.
+
+With thanks,
+
+{u[name]}""",
+}
+gavinwilliamson_email["target"] = {
+    "name": "Secretary of State for Education",
+    "email": "gavin.williamson.mp@parliament.uk",
+}
+
+belly_mujinga_mp = {
+    "subject": "Justice for Belly Mujinga",
+    "body": """
+Dear {t[name]},
+
+My name is {u[name]} and I am a resident of {t[constituency]}, at {u[address]}.
+
+I write further to my previous email regarding Black Lives Matter with a specific demand for justice for Belly Mujinga, a railway ticket office worker who contracted COVID-19 and subsequently died. I am sure you are aware that Mujinga, a key worker, was spat on by a member of the public claiming he was infectious on March 21.
+
+Despite this event taking place, a spokesperson for British Transport Police has recently stated that they will take no further action into the case, given that the “tragic death of Belly Mujinga was not a consequence of this incident.”
+
+However, in Glasgow, a man who spat at a police officer and joked about coronavirus has been jailed for twelve months.
+
+I recognise that there may be legal differences between each of the four nations, but it is unconscionable to me that there is such a gulf between the consequences of these two actions. Regardless of whether illness may or may not be attributed to the assault, it is an assault nonetheless, and an assault that in the case of Belly Mujinga has not been given due weight.
+
+I find this especially troubling following the report published into disproportionate BAME deaths due to COVID-19, and ask whether Belly Mujinga - a Congolese woman with underlying health issues, who was reportedly scared for her life - was a victim of a poor response to the coronavirus pandemic on the part of British authorities.
+
+I urge the UK government to seek to reopen the investigation into the assault on Belly Mujinga.
+
+Yours sincerely,
+
+{u[name]}""",
+}
+
+
+belly_mujinga_govia = {
+    "subject": "Justice for Belly Mujinga",
+    "body": """
+Dear {t[name]},
+
+I am writing to you in regards to the recent death of Belly Mujinga, who worked for Govia Thameslink Railway. Her death follows after an assault was carried out on 21st March in which her and colleagues were spat at and coughed on during their shift at London Victoria Station.
+
+As I am sure you are aware, it was revealed on 29th May that The British Transport Police ruled that they believed there was no link between the act of assault and her death and stated that ‘no further action will be taken’, closing the case. In spite of this Ms. Mujinga’s passing on 5th April comes just two weeks after the assault had taken place and after several days having been admitted to hospital and testing positive for COVID-19.
+
+Following the outcome in regards to Ms. Mujinga’s death and The British Transport Police’s dismissal of the case, I urge you as CEO of Govia Thameslink Railway, to take action on her behalf and to that of her loved ones following her death. As an essential worker, Ms. Mujinga was failed by the Govia Thameslink Rail to be protected after she had expressed concerns for her wellbeing due to respiratory issues. Ms. Mujinga made appeals to work away from crowds at the busy station due to there being no PPE provided for railway workers, her concerns were inadequately dismissed.
+
+In spite of the assault carried out and Ms. Mujinga’s passing it was reported by The Independent in an article released on 14th May by a worker at London Victoria station that “There’s not much being done to check all the staff, today is the first day we have had masks.” Going forward, it shows that you have not prioritised the protection and the safety of your staff to prevent such an act happening again in the future.
+
+So I ask, why did you ignore Belly’s requests to work away from crowds during the pandemic as she had underlying health issues?
+
+Further, why did it take weeks for Govia to surrender the CCTV footage to the police?
+
+As a concerned individual I urge you to recognise the needs of more effective regulations and protection of railway workers at Govia Thameslink Rail during this time and for an assault similar to that of Ms Mujinga which effectively cost her life does not take place again.
+
+Until responsible actions are taken to honour the death of Belly and prevent the future assault of your workers and you take full responsibility for your role in Belly's murder, I have decided to boycott Southern Rail, Gatwick Express, Great Northern and Thameslink.
+
+Regards,
+
+{u[name]}""",
+}
+belly_mujinga_govia["target"] = {
+    "name": "Patrick Verwer",
+    "email": "Patrick.Verwer@gtrailway.com",
+}
+
+
+shukri_abdi = {
+    "subject": "Justice For Shukri Abdi",
+    "body": """
+Dear {t[name]},
+
+As your constituent, I am writing to call upon you to take action against Hazel Wood High School for concerning patterns of failures to protect both staff and pupils from bullying, resulting in deaths; and Greater Manchester Police for failing to properly investigate the murder of Shukri Abdi due to institutionalised racism. We demand justice for Shukri Abdi.
+
+The body of Shukri, who first came to the UK in January 2017 as a refugee seeking a better life, was found in the River Irwell in Bury, Greater Manchester in June 2019. An inquest heard that Shukri had been threatened by her class peer/s and told: “if you don’t get into the water, I’m going to kill you”. I am utterly beyond outraged, saddened and disappointed that children in our society can be so badly let down and failed. Shukri has been described as an “angelic, funny and kind-hearted little girl” that had much to offer.
+
+There are very concerning patterns of failure to meet adequate safeguarding measures at Hazel Wood High School, who has since rebranded from Broad Oak Sports College. The latest Ofsted report concluded that the school was “inadequate” and has thus since been put on “special measures” by Her Majesty’s Chief Inspector, per section 44(1) of the Education Act 2005. Shurki has been woefully failed by Hazel Wood High School. Their incompetence can be argued to have played a key role in the murder of Shukri. Additionally, Manchester Evening News reported that in 2015 a “senior teacher, Caroline Bailey, at Broad Oak Sports College” (Hazel Wood High School) had committed suicide; an inquest heard that this was, yet again, due to “strategic bullying” from co-workers within the school. I urge you to raise these concerning patterns of failure to safeguard against bullying, resulting in deaths, at Hazel Wood High School, with the Secretary of State for Education, Gavin Williamson.
+
+Furthermore, Greater Manchester Police (GMP) must also be investigated for their ineptitude in investigating this murder, no less a sign of institutionalised racism that has failed yet another black life. Reports show that the Officers at the scene of the murder took witness statements from only two out of four present at Shukri’s death. Her murder was ruled by GMP to be an accident within two weeks. One can argue that Shukri’s murder has not been properly investigated due to her ethnic background and, therefore, has led to my loss of confidence in the impartiality of the GMP in serving to protect and uphold justice for all citizens. I urge you to raise these concerns with the Mayor of Manchester, Andy Burnham.
+
+Moreover, Shukri’s death can also be placed in a wider landscape of institutional racism within modern-day Britain. Yvette Cooper, Labour MP and chair of the home affairs select committee damned the “deeply unfair shambles” of how asylum seekers are accommodated. The Guardian analysis of Home Office data found that “more than half of all asylum seekers (57%) housed by the government are done so in the poorest third of the country”. I trust that we can agree that we must do more to support the most vulnerable in our society and that these statistics are wholly unacceptable.
+
+As you are well aware of the global outrage against injustices rooted in systemic and perpetual institutionalised racism, I leave you with the words of human rights activist and organiser of the protests demanding justice for Shukri Abdi, Bashir Ibrahim: “she was failed when she was alive and she’s still being failed now as she’s dead”.
+
+I look forward to your urgent response,
+
+Yours sincerely,
+
+{u[name]}
+""",
+}
+
+for t in [
+    mp_police,
+    gavinwilliamson_email,
+    belly_mujinga_mp,
+    belly_mujinga_govia,
+    shukri_abdi,
+]:
+    add_or_update_template(t)

--- a/submit_old_templates.py
+++ b/submit_old_templates.py
@@ -25,6 +25,8 @@ Regards,
 
 {u[name]}
     """,
+    "name": "Suspend Police Equipment Exports",
+    "topics": ["black-lives-matter"],
 }
 
 

--- a/tests.py
+++ b/tests.py
@@ -78,7 +78,7 @@ class TestEmailTemplate(unittest.TestCase):
             with self.subTest(b=b):
                 # Delete the "b" field
                 del dict[b]
-                # Email Template generation should succeed successfully
+                # Email Template generation should succeed
                 et = EmailTemplate(**dict)
 
     def test_generate_user_fields(self):

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,106 @@
+import unittest
+from copy import deepcopy
+from emailtemplates import EmailTemplate
+
+# Reference dictionaries for user and target info
+user_info = {
+    "name": "John Smith",
+    "address": "1 Test Road, Somewhere, AB1 2CD",
+}
+target_info = {
+    "name": "Big Bad Government",
+    "constituency": "Westminster",
+    "email": "bigbadboi@hotmail.co.uk",
+}
+
+# This dictionary represents how a template will be stored in the database
+example_template = {
+    # Subject field: To be entered in the subject field of mailto and gmail links
+    "subject": "Justice for an Email Template Example",
+    # Body field: Content of the template including dictionary lookups for auto-filling later
+    "body": "dear {t[name]},\nLots of complex ideas and thoughts\n expressed well (handle newlines) from: {u[name]} {u[address]}",
+    # Name of the template: ideally 3-4 words max to allow a quick description of this template, may be the same as the subject line of the email for some templates.
+    # This will be used to check if template already exists so AVOID RENAMING TEMPLATES
+    "name": "Three-Four Word description",
+    # List of topics that this email tackles,
+    # This will allow filtering templates by topic at a general level (eg "All Templates on Racial Injustice") and on a more specific level (eg "Belly Mujinga")
+    "topics": ["Wide, overarching issue", "Specific topic of this template"],
+    # URL linking to the author of the template: "This template was written by [This Person]("template_author_url")"
+    "author_url": "https://twitter.com/ACoolGuy/status/emailtemplateidea",
+    # URL linking to more information on this campaign: "More info for this campaign can be found [here]("template_more_info_url")"
+    "more_info_url": "https://campaign-website.com",
+    # The target the template is addressed to.
+    # The "target" field is only set if the target for the email is known before getting user data, i.e. always the same person.
+    # If the "target" field is unset, the target relies on user input, and thus we assume the target must be the local MP of the website user.
+    # In the future we may want to store targets separately, however for now we store their information as a dictionary under the target field of the template.
+    "target": {
+        # "Name" and "Email" are the only required fields for targets at the moment, however in the future more complex templates may require attributes such as "department"
+        "name": "CEO of Bad Company",
+        "email": "ceo@company.com",
+    },
+    # CC- carbon copy addresses: A list of emails to put in the cc field of the email, we may want to extend this later, for example to include LOCALMP or some other flag to allow an MP to be copied into an email to a head of a government department.
+    "cc": ["anotherperson@company.com"],
+    # The attributes of the user and target dictionaries which the body of the template requires to be filled correctly.
+    # Used for validation of the template against provided user & target info
+    "fields_used": {"target": ["name"], "user": ["name", "address"],},
+    # Flag setting template visibility
+    # Later when private campaigns are implemented we won't want to serve every template on the homepage - this flag allows us to disable templates without deleting them.
+    "public": True,
+}
+
+
+class TestEmailTemplate(unittest.TestCase):
+    def setUp(self):
+        self.template_dict = example_template
+
+    def test_missing_attributes(self):
+        """Tests to check EmailTemplate object creation fails as expected when template_dict is missing attributes"""
+        # Want essential components of a template to generate key errors:
+        for a in ["subject", "body", "name"]:
+            # Make a copy of the example dictionary
+            dict = deepcopy(self.template_dict)
+            with self.subTest(a=a):
+                # Delete the "a" field
+                del dict[a]
+                with self.assertRaises(KeyError):
+                    et = EmailTemplate(**dict)
+        # Unnecessary attributes should be able to be missing and still create a valid template
+        for b in [
+            "topics",
+            "author_url",
+            "more_info_url",
+            "target",
+            "cc",
+            "fields_used",
+            "public",
+        ]:
+            dict = deepcopy(self.template_dict)
+            with self.subTest(b=b):
+                # Delete the "b" field
+                del dict[b]
+                # Email Template generation should succeed successfully
+                et = EmailTemplate(**dict)
+
+    def test_generate_user_fields(self):
+        """
+        Tests the correct user fields are generated from a template body:
+        - Each field should only be extracted once (no duplicates)
+        - Attributes should be a single word
+        - The syntax for a field is strictly {t[attribute]} or {u[attribute]} (no newlines or missed brackets)
+        """
+        body = "dear {t[name]},\n I am  {u[name]} ... u[name] {uname} u[{] [{name_no_u}] {u[nameacrosslines]\n}  {u[name]} {u[address]}"
+        expected_fields = {"user": ["name", "address"], "target": ["name"]}
+        self.assertCountEqual(
+            EmailTemplate._generate_used_fields(body), expected_fields
+        )
+
+    def test_invalid_attributes_in_template(self):
+        """Tests that if there are invalid attributes in the body, the template fails"""
+        dict = deepcopy(self.template_dict)
+        dict["body"] = "Dear {t[names]}, {u[name]}"
+        with self.assertRaises(KeyError):
+            et = EmailTemplate(**dict)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rewritten most of `emailtemplates.py` to use a nice OOP setup that we can construct from python dictionaries stored in the database. Some functions are only templates for now, but the structure presented here allows easy inclusion of more advanced validation and dealing with newline issues (for example).

This should replace #19 once the script to store MP data (including political party) has been copied across.